### PR TITLE
Removes unused dependency + return this in apply method of patch.

### DIFF
--- a/Block/Adminhtml/Edit/Tab/CustomerAttributes.php
+++ b/Block/Adminhtml/Edit/Tab/CustomerAttributes.php
@@ -16,7 +16,6 @@ class CustomerAttributes extends Generic implements TabInterface
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Data\FormFactory $formFactory,
-        \Magento\Store\Model\System\Store $systemStore,
         array $data = []
     ) {
         $this->_coreRegistry = $registry;

--- a/Setup/Patch/Data/AddCustomerCompanyAttributes.php
+++ b/Setup/Patch/Data/AddCustomerCompanyAttributes.php
@@ -40,6 +40,8 @@ class AddCustomerCompanyAttributes implements DataPatchInterface
     {
         $this->createAttribute('bc_contact_no', 'BC Contact Number');
         $this->createAttribute('parent_customer_id', 'Parent Customer ID for Contacts');
+
+        return $this;
     }
 
     private function createAttribute($code, $label)


### PR DESCRIPTION
Similar fix as in https://github.com/NVision-Commerce-Solutions/module-customer-price/pull/4

Also, removes an unused dependency `\Magento\Store\Model\System\Store`


Found using phpstan on level 1:
```
 ------ -------------------------------------------------------------------------------------------------------------------------
  Line   module-core/Block/Adminhtml/Edit/Tab/CustomerAttributes.php
 ------ -------------------------------------------------------------------------------------------------------------------------
  15     Constructor of class Commerce365\Core\Block\Adminhtml\Edit\Tab\CustomerAttributes has an unused parameter $systemStore.
 ------ -------------------------------------------------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   module-core/Setup/Patch/Data/AddCustomerCompanyAttributes.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  42     Method Commerce365\Core\Setup\Patch\Data\AddCustomerCompanyAttributes::apply() should return $this(Commerce365\Core\Setup\Patch\Data\AddCustomerCompanyAttributes) but return statement is missing.
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```