### PR TITLE
Cleanup some code: removed unused method, add 'return this' in patche…

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -43,15 +43,4 @@ class Data extends AbstractHelper
     {
         $this->_logger->debug($message);
     }
-
-    public function getCustomerId()
-    {
-        if ($customerId = $this->customerSession->getCustomerId()) {
-            return $customerId;
-        }
-
-        if ($customerId = $this->httpContext->getValue(ContextPlugin::CUSTOMER_ID)) {
-            return $customerId;
-        }
-    }
 }

--- a/Setup/Patch/Data/AddCustomerCompanyAttributes.php
+++ b/Setup/Patch/Data/AddCustomerCompanyAttributes.php
@@ -40,6 +40,8 @@ class AddCustomerCompanyAttributes implements DataPatchInterface
     {
         $this->createAttribute('bc_contact_no', 'BC Contact Number');
         $this->createAttribute('parent_customer_id', 'Parent Customer ID for Contacts');
+
+        return $this;
     }
 
     private function createAttribute($code, $label)

--- a/Setup/Patch/Data/ChangeParentCustomerAttributeLabel.php
+++ b/Setup/Patch/Data/ChangeParentCustomerAttributeLabel.php
@@ -28,14 +28,12 @@ class ChangeParentCustomerAttributeLabel implements DataPatchInterface
 
     public function apply()
     {
-        $this->moduleDataSetup->startSetup();
-
         $this->moduleDataSetup->getConnection()->update(
             $this->moduleDataSetup->getTable('eav_attribute'),
             ['frontend_label' => 'Parent Customer'],
             ['attribute_code = ?' => 'parent_customer_id']
         );
 
-        $this->moduleDataSetup->endSetup();
+        return $this;
     }
 }


### PR DESCRIPTION
…s, remove startSetup and endSetup calls, this is considered a bad practice.

Changes proposed here:
- removes `getCustomerId` method, the code inside it is not valid, and it looks like this method isn't being used, so this can be removed in my opinion. This fixes #1 
- Added `return $this;` to all patches's `apply` method. Which it should do according to [the docs](https://github.com/magento/magento2/blob/2.4.6/lib/internal/Magento/Framework/Setup/Patch/PatchInterface.php#L31).
- Removed call to `startSetup` and `endSetup`, this is really a bad idea that for some reason has been going around in the community for the last 10 years or so, but it's considered bad practice, see [explanation here written by a Magento/Adobe employee](https://community.magento.com/t5/Magento-DevBlog/Mysterious-startSetup-and-endSetup-Methods/ba-p/68483)